### PR TITLE
Added ppc64le to architecture list

### DIFF
--- a/tg_owt.spec
+++ b/tg_owt.spec
@@ -64,7 +64,7 @@ BuildRequires: ffmpeg-devel
 %endif
 
 # Disabling all low-memory architectures.
-ExclusiveArch: x86_64 aarch64
+ExclusiveArch: x86_64 aarch64 ppc64le
 
 %description
 Special fork of the OpenWebRTC library for the Telegram messenger.


### PR DESCRIPTION
This library, along with telegram-desktop, have been tested on a POWER9 system running Fedora 36 and all functionality appears to work as expected.